### PR TITLE
Add check control before initialize root path for handleStatus

### DIFF
--- a/__tests__/application.spec.ts
+++ b/__tests__/application.spec.ts
@@ -90,7 +90,6 @@ describe('[application.ts]', () => {
 
     // Assert
     expect(routerMock.use.calledWithExactly(application.applicationInfoMiddleware)).to.eq(true);
-    expect(routerMock.get.calledWithExactly('/', application.handleStatus)).to.eq(true);
     expect(routerMock.get.calledWith(configuration.pages[0].configuration.matcher, configuration.pages[0].handle)).to.eq(true);
   });
 

--- a/src/application.ts
+++ b/src/application.ts
@@ -29,14 +29,9 @@ class Application {
 
   init() {
     this.router.use(this.applicationInfoMiddleware);
-    this.checkRootPathExists();
     this.configuration.pages.forEach(page => {
       this.router.get(page.configuration.matcher, page.handle);
     });
-  }
-
-  private checkRootPathExists() {
-    this.configuration.pages.some(page => page.configuration.matcher !== '/') && this.router.get('/', this.handleStatus)
   }
 
   toJSON() {

--- a/src/application.ts
+++ b/src/application.ts
@@ -29,10 +29,14 @@ class Application {
 
   init() {
     this.router.use(this.applicationInfoMiddleware);
-    this.router.get('/', this.handleStatus);
+    this.checkRootPathExists();
     this.configuration.pages.forEach(page => {
       this.router.get(page.configuration.matcher, page.handle);
     });
+  }
+
+  private checkRootPathExists() {
+    this.configuration.pages.some(page => page.configuration.matcher !== '/') && this.router.get('/', this.handleStatus)
   }
 
   toJSON() {

--- a/src/page.ts
+++ b/src/page.ts
@@ -44,7 +44,11 @@ class Page {
     configuration: PageSettings,
     engine: Engine
   ) {
-    this.configuration = Object.assign(defaultPageSettings, configuration);
+    
+    this.configuration = {
+      ...defaultPageSettings,
+      ...configuration
+    }
 
     this.handle = this.handle.bind(this);
     this.engine = engine;


### PR DESCRIPTION
I added check root path is allocated control.

The case: when I want use "/" path as dynamic rendering, the "this.handleStatus" has been initialized first. Express does not support override routes beforehand.

This solution provides; 
 - when does page handle "/" as exact path, just use it or leave it for config rendering.
