### PR TITLE
Add passing configuration parameters for debugging puppeteer

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,24 @@ dynamicRender
   });
 ```
 
+*(Optional) You can pass configuration parameters for debugging purposes*
+```js
+const config = {
+  puppeteer: {
+    headless: false,
+    ignoreHTTPSErrors: true,
+    devtools: true,
+  },
+  port: 8080
+}
+
+dynamicRender
+  .start(config)
+  .then(port => {
+    console.log(`Prerender listening on ${port}`);
+  });
+```
+
 Now you can send request to `http://localhost:8080/render/example-web/example/35235657`, dynamic render will respond with rendered content.
 
 

--- a/demo/demo.ts
+++ b/demo/demo.ts
@@ -2,6 +2,7 @@ import dynamicRender from "../src";
 import fs from "fs";
 import * as path from "path";
 
+
 const placeholderPng = fs.readFileSync(path.join(__dirname, './png_placeholder'));
 const placeholderJpg = fs.readFileSync(path.join(__dirname, './jpg_placeholder'));
 
@@ -124,9 +125,17 @@ dynamicRender.application('mobile-web', {
   origin: 'https://m.trendyol.com'
 });
 
+const config = {
+  puppeteer: {
+    headless: false,
+    ignoreHTTPSErrors: true,
+    devtools: true,
+  },
+  port: 8080
+}
 
 dynamicRender
-  .start()
+  .start(config)
   .then(port => {
     console.log(`Prerender listening on ${port}`);
   });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "dynamic-render",
-  "version": "1.0.0-alpha.1",
+  "version": "1.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dynamic-render",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Dynamic Render is a headless Chrome rendering solution designed to render & serialise web pages on the fly.",
   "main": "dist/index.js",
   "scripts": {

--- a/src/dynamic-render.ts
+++ b/src/dynamic-render.ts
@@ -8,11 +8,20 @@ import express from "express";
 
 
 interface PrerenderDefaultConfiguration extends ServerConfiguration {
-
+ puppeteer?: {
+   headless: boolean,
+   devtools: boolean,
+   ignoreHTTPSErrors: boolean,
+ }
 }
 
 const defaultConfiguration = {
-  port: 8080
+  port: 8080,
+  puppeteer: {
+    headless: true,
+    ignoreHTTPSErrors: true,
+    devtools: false,
+ }
 };
 
 class DynamicRender {
@@ -34,8 +43,11 @@ class DynamicRender {
   }
 
   async start(configuration?: PrerenderDefaultConfiguration) {
-    this.configuration = Object.assign(this.configuration, configuration);
-    await this.engine.init();
+    this.configuration = {
+      ...defaultConfiguration,
+      ...configuration
+    }
+    await this.engine.init(this.configuration.puppeteer);
     await this.registerApplications();
     return this.server.listen(this.configuration.port);
   }

--- a/src/dynamic-render.ts
+++ b/src/dynamic-render.ts
@@ -5,14 +5,11 @@ import {Application, ApplicationConfig} from "./application";
 import {Hook, HookConfiguration} from "./hook";
 import {Interceptor, InterceptorConfiguration} from "./interceptor";
 import express from "express";
+import { LaunchOptions } from 'puppeteer';
 
 
-interface PrerenderDefaultConfiguration extends ServerConfiguration {
- puppeteer?: {
-   headless: boolean,
-   devtools: boolean,
-   ignoreHTTPSErrors: boolean,
- }
+interface PrerenderDefaultConfiguration  extends ServerConfiguration {
+ puppeteer: Partial<LaunchOptions>
 }
 
 const defaultConfiguration = {
@@ -45,7 +42,7 @@ class DynamicRender {
   async start(configuration?: PrerenderDefaultConfiguration) {
     this.configuration = {
       ...defaultConfiguration,
-      ...configuration
+      ...configuration,
     }
     await this.engine.init(this.configuration.puppeteer);
     await this.registerApplications();

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -1,4 +1,4 @@
-import puppeteer, {Browser, EmulateOptions, LoadEvent} from "puppeteer";
+import puppeteer, {Browser, EmulateOptions, LoadEvent, LaunchOptions} from "puppeteer";
 import {Interceptor} from "./interceptor";
 import {Hook} from "./hook";
 import {ResponseCache} from "./response-cache";
@@ -24,7 +24,7 @@ class Engine {
     this.onResponse = this.onResponse.bind(this);
   }
 
-  async init(config?: any) {
+  async init(config?: Partial<LaunchOptions>) {
     this.browser = await puppeteer.launch({
       headless: true,
       ignoreHTTPSErrors: true,

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -24,11 +24,12 @@ class Engine {
     this.onResponse = this.onResponse.bind(this);
   }
 
-  async init() {
+  async init(config: any) {
     this.browser = await puppeteer.launch({
       headless: true,
       ignoreHTTPSErrors: true,
-      devtools: false
+      devtools: false,
+      ...config
     });
   }
 

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -24,7 +24,7 @@ class Engine {
     this.onResponse = this.onResponse.bind(this);
   }
 
-  async init(config: any) {
+  async init(config?: any) {
     this.browser = await puppeteer.launch({
       headless: true,
       ignoreHTTPSErrors: true,


### PR DESCRIPTION
This feature contains; dynamicRender.start() method is now able to read puppeteer config.

```js
const config = {
  puppeteer: {
    headless: false,
    ignoreHTTPSErrors: true,
    devtools: true,
  },
  port: 8080
}

dynamicRender
  .start(config)
  .then(port => {
    console.log(`Prerender listening on ${port}`);
  });
```